### PR TITLE
修复更新的字段是MySQL关键字的时候更新失败

### DIFF
--- a/entity.php
+++ b/entity.php
@@ -892,7 +892,7 @@ class dao
         $binds[':old_version'] = $entity->version;
 
         foreach ($this->get_dirty($entity) as $column => $value) {
-            $update[] = "$column = :$column";
+            $update[] = "`$column` = :$column";
             $binds[":$column"] = $value;
         }
 


### PR DESCRIPTION
假如我的实体里面使用了MySQL的关键字作为字段名，虽然创建数据没问题，但是更新数据的时候会失败。