### PR TITLE
修复当使用sock方式连接redis时出现Name or service not known的问题

### DIFF
--- a/cache/redis.php
+++ b/cache/redis.php
@@ -24,7 +24,7 @@ function _redis_connection(array $config)
             $redis = new Redis();
 
             if ($is_sock) {
-                $redis->connect($config['sock'], $config['timeout']);
+                $redis->connect($config['sock']);
             } else {
                 $redis->connect($config['host'], $config['port'], $config['timeout']);
             }


### PR DESCRIPTION
这个修改修复了以下问题：
    <br />
    <b>Warning</b>:  Redis::connect(): php_network_getaddresses: getaddrinfo failed: Name or service not known in 
    <b>/your_project_path/frame/cache/redis.php</b> on line <b>27</b><br />